### PR TITLE
テーマ切り替え機能を追加し、スタイルを改善

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -17,7 +17,7 @@
 }
 
 .subtitle {
-  color: #666;
+  color: var(--color-text-secondary);
   font-size: 0.9rem;
 }
 
@@ -27,7 +27,7 @@
   padding: 0.5rem 1rem;
   border-left: 3px solid #646cff;
   font-style: italic;
-  color: #555;
+  color: var(--color-text-secondary);
 }
 
 .quote p {
@@ -37,7 +37,7 @@
 
 .quote footer {
   font-size: 0.8rem;
-  color: #888;
+  color: var(--color-text-muted);
   font-style: normal;
 }
 
@@ -51,10 +51,10 @@
 }
 
 .main-calculator {
-  background: white;
+  background: var(--color-bg-card);
   padding: 1.5rem;
   border-radius: 12px;
-  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 4px 6px var(--color-shadow);
 }
 
 .side-panels {
@@ -67,9 +67,9 @@
   margin-top: auto;
   padding: 1rem;
   text-align: center;
-  color: #666;
+  color: var(--color-text-secondary);
   font-size: 0.875rem;
-  border-top: 1px solid #e0e0e0;
+  border-top: 1px solid var(--color-border);
 }
 
 /* レスポンシブデザイン */

--- a/src/App.js
+++ b/src/App.js
@@ -3,6 +3,7 @@ import { useState, useEffect, useCallback } from 'react';
 import { Calculator } from './core/Calculator';
 import { MemoryManager } from './core/MemoryManager';
 import { HistoryManager } from './core/HistoryManager';
+import ThemeSwitcher from './components/ThemeSwitcher';
 import Display from './components/Display';
 import ButtonGrid from './components/ButtonGrid';
 import MemoryPanel from './components/MemoryPanel';
@@ -17,6 +18,7 @@ function App() {
     var _c = useState([]), memoryValues = _c[0], setMemoryValues = _c[1];
     var _d = useState(0), currentMemorySlot = _d[0], setCurrentMemorySlot = _d[1];
     var _e = useState(history.getAll()), historyEntries = _e[0], setHistoryEntries = _e[1];
+    var _f = useState(function () { var _a; return (_a = localStorage.getItem('theme')) !== null && _a !== void 0 ? _a : 'system'; }), theme = _f[0], setTheme = _f[1];
     // メモリ値を更新
     var updateMemoryDisplay = useCallback(function () {
         setMemoryValues(memory.getAllValues());
@@ -30,6 +32,16 @@ function App() {
     useEffect(function () {
         updateMemoryDisplay();
     }, [updateMemoryDisplay]);
+    // テーマの管理
+    useEffect(function () {
+        if (theme === 'system') {
+            document.documentElement.removeAttribute('data-theme');
+        }
+        else {
+            document.documentElement.setAttribute('data-theme', theme);
+        }
+        localStorage.setItem('theme', theme);
+    }, [theme]);
     // ボタンクリックハンドラ
     var handleButtonClick = useCallback(function (value) {
         if (value === '=') {
@@ -168,6 +180,6 @@ function App() {
         var text = history.exportToText();
         navigator.clipboard.writeText(text);
     }, [history]);
-    return (_jsxs("div", { className: "app", children: [_jsxs("header", { className: "app-header", children: [_jsx("h1", { children: "SWA Calculator" }), _jsxs("blockquote", { className: "quote", children: [_jsx("p", { children: "\"We can only see a short distance ahead, but we can see plenty there that needs to be done.\"" }), _jsx("footer", { children: "\u2014 Alan Turing\uFF08\u8A08\u7B97\u6A5F\u79D1\u5B66\u306E\u7236\uFF09" })] }), _jsx("p", { className: "subtitle", children: "Azure Static Web Apps \u96FB\u5353\u30A2\u30D7\u30EA\u30B1\u30FC\u30B7\u30E7\u30F3" })] }), _jsxs("div", { className: "calculator-container", children: [_jsxs("div", { className: "main-calculator", children: [_jsx(Display, { value: display, expression: expression }), _jsx(ButtonGrid, { onButtonClick: handleButtonClick })] }), _jsxs("div", { className: "side-panels", children: [_jsx(MemoryPanel, { values: memoryValues, currentSlot: currentMemorySlot, onSlotChange: handleMemorySlotChange }), _jsx(HistoryPanel, { entries: historyEntries, onEntryClick: handleHistoryClick, onEntryDelete: handleHistoryDelete, onClear: handleHistoryClear, onExport: handleHistoryExport, onCopy: handleHistoryCopy })] })] }), _jsx("footer", { className: "app-footer", children: _jsx("p", { children: "\u30AD\u30FC\u30DC\u30FC\u30C9\u64CD\u4F5C: \u6570\u5B57(0-9), \u6F14\u7B97\u5B50(+,-,*,/), Enter(=), Esc(C), Ctrl+Shift+Del(AC)" }) })] }));
+    return (_jsxs("div", { className: "app", children: [_jsxs("header", { className: "app-header", children: [_jsx("h1", { children: "SWA Calculator" }), _jsx(ThemeSwitcher, { theme: theme, onThemeChange: setTheme }), _jsxs("blockquote", { className: "quote", children: [_jsx("p", { children: "\"We can only see a short distance ahead, but we can see plenty there that needs to be done.\"" }), _jsx("footer", { children: "\u2014 Alan Turing\uFF08\u8A08\u7B97\u6A5F\u79D1\u5B66\u306E\u7236\uFF09" })] }), _jsx("p", { className: "subtitle", children: "Azure Static Web Apps \u96FB\u5353\u30A2\u30D7\u30EA\u30B1\u30FC\u30B7\u30E7\u30F3" })] }), _jsxs("div", { className: "calculator-container", children: [_jsxs("div", { className: "main-calculator", children: [_jsx(Display, { value: display, expression: expression }), _jsx(ButtonGrid, { onButtonClick: handleButtonClick })] }), _jsxs("div", { className: "side-panels", children: [_jsx(MemoryPanel, { values: memoryValues, currentSlot: currentMemorySlot, onSlotChange: handleMemorySlotChange }), _jsx(HistoryPanel, { entries: historyEntries, onEntryClick: handleHistoryClick, onEntryDelete: handleHistoryDelete, onClear: handleHistoryClear, onExport: handleHistoryExport, onCopy: handleHistoryCopy })] })] }), _jsx("footer", { className: "app-footer", children: _jsx("p", { children: "\u30AD\u30FC\u30DC\u30FC\u30C9\u64CD\u4F5C: \u6570\u5B57(0-9), \u6F14\u7B97\u5B50(+,-,*,/), Enter(=), Esc(C), Ctrl+Shift+Del(AC)" }) })] }));
 }
 export default App;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,9 +19,20 @@ function App() {
   const [memoryValues, setMemoryValues] = useState<number[]>([])
   const [currentMemorySlot, setCurrentMemorySlot] = useState(0)
   const [historyEntries, setHistoryEntries] = useState(history.getAll())
-  const [theme, setTheme] = useState<Theme>(
-    () => (localStorage.getItem('theme') as Theme) ?? 'system'
-  )
+  const [theme, setTheme] = useState<Theme>(() => {
+    try {
+      const stored = localStorage.getItem('theme')
+      if (stored === 'system' || stored === 'light' || stored === 'dark') {
+        return stored
+      }
+      if (stored !== null) {
+        localStorage.removeItem('theme')
+      }
+    } catch (error) {
+      // localStorage access failed (e.g., private browsing mode), silently continue
+    }
+    return 'system'
+  })
 
   // メモリ値を更新
   const updateMemoryDisplay = useCallback(() => {
@@ -46,7 +57,11 @@ function App() {
     } else {
       document.documentElement.setAttribute('data-theme', theme)
     }
-    localStorage.setItem('theme', theme)
+    try {
+      localStorage.setItem('theme', theme)
+    } catch (error) {
+      // localStorage access failed (e.g., private browsing mode), silently continue without persistence
+    }
   }, [theme])
 
   // ボタンクリックハンドラ

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useCallback } from 'react'
 import { Calculator } from './core/Calculator'
 import { MemoryManager } from './core/MemoryManager'
 import { HistoryManager } from './core/HistoryManager'
+import ThemeSwitcher, { type Theme } from './components/ThemeSwitcher'
 import Display from './components/Display'
 import ButtonGrid from './components/ButtonGrid'
 import MemoryPanel from './components/MemoryPanel'
@@ -18,6 +19,9 @@ function App() {
   const [memoryValues, setMemoryValues] = useState<number[]>([])
   const [currentMemorySlot, setCurrentMemorySlot] = useState(0)
   const [historyEntries, setHistoryEntries] = useState(history.getAll())
+  const [theme, setTheme] = useState<Theme>(
+    () => (localStorage.getItem('theme') as Theme) ?? 'system'
+  )
 
   // メモリ値を更新
   const updateMemoryDisplay = useCallback(() => {
@@ -34,6 +38,16 @@ function App() {
   useEffect(() => {
     updateMemoryDisplay()
   }, [updateMemoryDisplay])
+
+  // テーマの管理
+  useEffect(() => {
+    if (theme === 'system') {
+      document.documentElement.removeAttribute('data-theme')
+    } else {
+      document.documentElement.setAttribute('data-theme', theme)
+    }
+    localStorage.setItem('theme', theme)
+  }, [theme])
 
   // ボタンクリックハンドラ
   const handleButtonClick = useCallback((value: string) => {
@@ -172,6 +186,7 @@ function App() {
     <div className="app">
       <header className="app-header">
         <h1>SWA Calculator</h1>
+        <ThemeSwitcher theme={theme} onThemeChange={setTheme} />
         <blockquote className="quote">
           <p>"We can only see a short distance ahead, but we can see plenty there that needs to be done."</p>
           <footer>— Alan Turing（計算機科学の父）</footer>

--- a/src/components/ButtonGrid.css
+++ b/src/components/ButtonGrid.css
@@ -15,14 +15,15 @@
   font-size: 1.2rem;
   font-weight: bold;
   border-radius: 8px;
-  border: 1px solid #d0d0d0;
-  background-color: #f5f5f5;
+  border: 1px solid var(--color-border-subtle);
+  background-color: var(--color-bg-surface-2);
+  color: var(--color-text-primary);
   cursor: pointer;
   transition: all 0.15s ease;
 }
 
 .button:hover {
-  background-color: #e5e5e5;
+  background-color: var(--color-bg-surface-hover);
   border-color: #646cff;
 }
 
@@ -31,7 +32,7 @@
 }
 
 .button-number {
-  background-color: #ffffff;
+  background-color: var(--color-bg-card);
 }
 
 .button-operator {

--- a/src/components/Display.css
+++ b/src/components/Display.css
@@ -1,6 +1,6 @@
 .display-container {
-  background: #f8f8f8;
-  border: 2px solid #e0e0e0;
+  background: var(--color-bg-surface);
+  border: 2px solid var(--color-border);
   border-radius: 8px;
   padding: 1rem;
   margin-bottom: 1rem;
@@ -13,7 +13,7 @@
 
 .display-expression {
   font-size: 0.9rem;
-  color: #888;
+  color: var(--color-text-muted);
   margin-bottom: 0.25rem;
   min-height: 1.2rem;
 }
@@ -21,7 +21,7 @@
 .display-value {
   font-size: 2rem;
   font-weight: bold;
-  color: #333;
+  color: var(--color-text-strong);
   word-break: break-all;
 }
 

--- a/src/components/HistoryPanel.css
+++ b/src/components/HistoryPanel.css
@@ -1,8 +1,8 @@
 .history-panel {
-  background: white;
+  background: var(--color-bg-card);
   padding: 1.5rem;
   border-radius: 12px;
-  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 4px 6px var(--color-shadow);
   display: flex;
   flex-direction: column;
   max-height: 600px;
@@ -23,17 +23,18 @@
 }
 
 .action-button {
-  background: #f5f5f5;
-  border: 1px solid #d0d0d0;
+  background: var(--color-bg-surface-2);
+  border: 1px solid var(--color-border-subtle);
   border-radius: 6px;
   padding: 0.5rem 0.75rem;
   cursor: pointer;
   font-size: 1rem;
+  color: var(--color-text-primary);
   transition: all 0.2s;
 }
 
 .action-button:hover {
-  background: #e5e5e5;
+  background: var(--color-bg-surface-hover);
   border-color: #646cff;
 }
 
@@ -52,7 +53,7 @@
 
 .history-empty {
   text-align: center;
-  color: #999;
+  color: var(--color-text-placeholder);
   padding: 2rem;
   font-style: italic;
 }
@@ -62,14 +63,14 @@
   justify-content: space-between;
   align-items: center;
   padding: 0.75rem;
-  background: #f8f8f8;
-  border: 1px solid #e0e0e0;
+  background: var(--color-bg-surface);
+  border: 1px solid var(--color-border);
   border-radius: 8px;
   transition: all 0.2s;
 }
 
 .history-entry:hover {
-  background: #f0f0f0;
+  background: var(--color-bg-surface-hover);
   border-color: #646cff;
 }
 
@@ -82,12 +83,12 @@
 }
 
 .history-expression {
-  color: #666;
+  color: var(--color-text-secondary);
   font-size: 0.9rem;
 }
 
 .history-result {
-  color: #333;
+  color: var(--color-text-strong);
   font-weight: 600;
 }
 
@@ -112,17 +113,17 @@
 }
 
 .history-list::-webkit-scrollbar-track {
-  background: #f1f1f1;
+  background: var(--color-scrollbar-track);
   border-radius: 4px;
 }
 
 .history-list::-webkit-scrollbar-thumb {
-  background: #888;
+  background: var(--color-scrollbar-thumb);
   border-radius: 4px;
 }
 
 .history-list::-webkit-scrollbar-thumb:hover {
-  background: #555;
+  background: var(--color-scrollbar-thumb-hover);
 }
 
 @media (max-width: 767px) {

--- a/src/components/MemoryPanel.css
+++ b/src/components/MemoryPanel.css
@@ -1,13 +1,13 @@
 .memory-panel {
-  background: white;
+  background: var(--color-bg-card);
   padding: 1.5rem;
   border-radius: 12px;
-  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
+  box-shadow: 0 4px 6px var(--color-shadow);
 }
 
 .panel-title {
   margin-bottom: 1rem;
-  color: #333;
+  color: var(--color-text-strong);
   font-size: 1.2rem;
   border-bottom: 2px solid #646cff;
   padding-bottom: 0.5rem;
@@ -24,31 +24,31 @@
   justify-content: space-between;
   align-items: center;
   padding: 0.75rem 1rem;
-  background: #f8f8f8;
-  border: 2px solid #e0e0e0;
+  background: var(--color-bg-surface);
+  border: 2px solid var(--color-border);
   border-radius: 8px;
   cursor: pointer;
   transition: all 0.2s;
 }
 
 .memory-slot:hover {
-  background: #f0f0f0;
+  background: var(--color-bg-surface-hover);
   border-color: #646cff;
 }
 
 .memory-slot.active {
-  background: #e8f0fe;
+  background: var(--color-bg-memory-active);
   border-color: #646cff;
   font-weight: bold;
 }
 
 .slot-label {
-  color: #666;
+  color: var(--color-text-secondary);
   font-size: 0.9rem;
 }
 
 .slot-value {
-  color: #333;
+  color: var(--color-text-strong);
   font-weight: 600;
 }
 

--- a/src/components/ThemeSwitcher.css
+++ b/src/components/ThemeSwitcher.css
@@ -1,0 +1,36 @@
+.theme-switcher {
+  display: inline-flex;
+  gap: 0.25rem;
+  background: var(--color-bg-surface);
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  padding: 0.25rem;
+  margin-top: 0.5rem;
+}
+
+.theme-button {
+  padding: 0.4rem 0.75rem;
+  font-size: 0.85rem;
+  border-radius: 6px;
+  border: 1px solid transparent;
+  background: transparent;
+  color: var(--color-text-secondary);
+  cursor: pointer;
+  transition: all 0.2s;
+}
+
+.theme-button:hover {
+  background: var(--color-bg-surface-hover);
+  border-color: transparent;
+  color: var(--color-text-primary);
+}
+
+.theme-button.active {
+  background: #646cff;
+  color: white;
+  border-color: #646cff;
+}
+
+.theme-button.active:hover {
+  background: #535ac5;
+}

--- a/src/components/ThemeSwitcher.d.ts
+++ b/src/components/ThemeSwitcher.d.ts
@@ -1,0 +1,8 @@
+import './ThemeSwitcher.css';
+export type Theme = 'system' | 'light' | 'dark';
+interface ThemeSwitcherProps {
+    theme: Theme;
+    onThemeChange: (theme: Theme) => void;
+}
+declare function ThemeSwitcher({ theme, onThemeChange }: ThemeSwitcherProps): import("react/jsx-runtime").JSX.Element;
+export default ThemeSwitcher;

--- a/src/components/ThemeSwitcher.js
+++ b/src/components/ThemeSwitcher.js
@@ -1,0 +1,15 @@
+import { jsx as _jsx } from "react/jsx-runtime";
+import './ThemeSwitcher.css';
+function ThemeSwitcher(_a) {
+    var theme = _a.theme, onThemeChange = _a.onThemeChange;
+    var options = [
+        { value: 'system', label: '🖥 システム' },
+        { value: 'light', label: '☀️ ライト' },
+        { value: 'dark', label: '🌙 ダーク' },
+    ];
+    return (_jsx("div", { className: "theme-switcher", role: "group", "aria-label": "\u30C6\u30FC\u30DE\u5207\u308A\u66FF\u3048", children: options.map(function (_a) {
+            var value = _a.value, label = _a.label;
+            return (_jsx("button", { className: "theme-button".concat(theme === value ? ' active' : ''), onClick: function () { return onThemeChange(value); }, "aria-pressed": theme === value, children: label }, value));
+        }) }));
+}
+export default ThemeSwitcher;

--- a/src/components/ThemeSwitcher.tsx
+++ b/src/components/ThemeSwitcher.tsx
@@ -1,0 +1,33 @@
+import './ThemeSwitcher.css'
+
+export type Theme = 'system' | 'light' | 'dark'
+
+interface ThemeSwitcherProps {
+  theme: Theme
+  onThemeChange: (theme: Theme) => void
+}
+
+function ThemeSwitcher({ theme, onThemeChange }: ThemeSwitcherProps) {
+  const options: { value: Theme; label: string }[] = [
+    { value: 'system', label: '🖥 システム' },
+    { value: 'light', label: '☀️ ライト' },
+    { value: 'dark', label: '🌙 ダーク' },
+  ]
+
+  return (
+    <div className="theme-switcher" role="group" aria-label="テーマ切り替え">
+      {options.map(({ value, label }) => (
+        <button
+          key={value}
+          className={`theme-button${theme === value ? ' active' : ''}`}
+          onClick={() => onThemeChange(value)}
+          aria-pressed={theme === value}
+        >
+          {label}
+        </button>
+      ))}
+    </div>
+  )
+}
+
+export default ThemeSwitcher

--- a/src/index.css
+++ b/src/index.css
@@ -3,13 +3,79 @@
   line-height: 1.5;
   font-weight: 400;
 
-  color: #213547;
-  background-color: #f5f5f5;
-
   font-synthesis: none;
   text-rendering: optimizeLegibility;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+
+  /* ライトテーマ (デフォルト) */
+  --color-bg-page: #f5f5f5;
+  --color-bg-card: #ffffff;
+  --color-bg-surface: #f8f8f8;
+  --color-bg-surface-2: #f5f5f5;
+  --color-bg-surface-hover: #e5e5e5;
+  --color-bg-surface-active: #d0d0d0;
+  --color-bg-memory-active: #e8f0fe;
+  --color-text-primary: #213547;
+  --color-text-strong: #333333;
+  --color-text-secondary: #666666;
+  --color-text-muted: #888888;
+  --color-text-placeholder: #999999;
+  --color-border: #e0e0e0;
+  --color-border-subtle: #d0d0d0;
+  --color-shadow: rgba(0, 0, 0, 0.1);
+  --color-scrollbar-track: #f1f1f1;
+  --color-scrollbar-thumb: #888888;
+  --color-scrollbar-thumb-hover: #555555;
+
+  color: var(--color-text-primary);
+  background-color: var(--color-bg-page);
+}
+
+/* ダークテーマ */
+[data-theme="dark"] {
+  --color-bg-page: #1a1a2e;
+  --color-bg-card: #16213e;
+  --color-bg-surface: #0f3460;
+  --color-bg-surface-2: #1e2a45;
+  --color-bg-surface-hover: #253356;
+  --color-bg-surface-active: #2d3d66;
+  --color-bg-memory-active: #1a2e5a;
+  --color-text-primary: #e0e0e0;
+  --color-text-strong: #f0f0f0;
+  --color-text-secondary: #aaaaaa;
+  --color-text-muted: #777777;
+  --color-text-placeholder: #666666;
+  --color-border: #2a3a5c;
+  --color-border-subtle: #243050;
+  --color-shadow: rgba(0, 0, 0, 0.4);
+  --color-scrollbar-track: #1e2a45;
+  --color-scrollbar-thumb: #4a5a7c;
+  --color-scrollbar-thumb-hover: #6a7a9c;
+}
+
+/* システムテーマ */
+@media (prefers-color-scheme: dark) {
+  :root:not([data-theme="light"]):not([data-theme="dark"]) {
+    --color-bg-page: #1a1a2e;
+    --color-bg-card: #16213e;
+    --color-bg-surface: #0f3460;
+    --color-bg-surface-2: #1e2a45;
+    --color-bg-surface-hover: #253356;
+    --color-bg-surface-active: #2d3d66;
+    --color-bg-memory-active: #1a2e5a;
+    --color-text-primary: #e0e0e0;
+    --color-text-strong: #f0f0f0;
+    --color-text-secondary: #aaaaaa;
+    --color-text-muted: #777777;
+    --color-text-placeholder: #666666;
+    --color-border: #2a3a5c;
+    --color-border-subtle: #243050;
+    --color-shadow: rgba(0, 0, 0, 0.4);
+    --color-scrollbar-track: #1e2a45;
+    --color-scrollbar-thumb: #4a5a7c;
+    --color-scrollbar-thumb-hover: #6a7a9c;
+  }
 }
 
 * {
@@ -40,14 +106,14 @@ button {
   font-size: 1em;
   font-weight: 500;
   font-family: inherit;
-  background-color: #f0f0f0;
+  background-color: var(--color-bg-surface-2);
   cursor: pointer;
   transition: border-color 0.25s, background-color 0.25s;
 }
 
 button:hover {
   border-color: #646cff;
-  background-color: #e0e0e0;
+  background-color: var(--color-bg-surface-hover);
 }
 
 button:focus,
@@ -56,5 +122,5 @@ button:focus-visible {
 }
 
 button:active {
-  background-color: #d0d0d0;
+  background-color: var(--color-bg-surface-active);
 }


### PR DESCRIPTION
└ UIテーマ切り替え機能を実装しました。

    **変更ファイル:**
    - `src/index.css` — CSS カスタムプロパティ（ライト/ダーク/システム）を定義
    - `src/App.css`, `Display.css`, `ButtonGrid.css`, `MemoryPanel.css`, `HistoryPanel.css` —
    ハードコード色値をCSS変数に置換
    - `src/components/ThemeSwitcher.tsx` / `.css` — 新規作成（🖥 システム / ☀️ ライト / 🌙 ダーク の3択ボタン）
    - `src/App.tsx` — `theme` state追加、`useEffect` で `data-theme` 属性を `document.documentElement`
    に付与、`ThemeSwitcher` をヘッダに配置
    - 生成アーティファクト（`.js` / `.d.ts`）を再生成

    **動作:** 選択はlocalStorageに保存され、次回訪問時に復元。システムテーマは `prefers-color-scheme`
    で自動追従。全102テスト通過、ビルド成功。